### PR TITLE
Remove orphan containers before starting up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ logs:
 .PHONY: logs
 
 down:
+	@# Remove any lingering container connected to lazarus_net
+	docker network inspect --format '{{range $$v := .Containers}}{{printf "%s\n" $$v.Name}}{{end}}' "lazarus_net" | xargs --no-run-if-empty docker stop
 	docker-compose -f docker/docker-compose.yaml stop --timeout 1
 	docker-compose -f docker/docker-compose.yaml down --remove-orphans
 .PHONY: down


### PR DESCRIPTION
Quick fix that allow us to call `make` idempotently, without worrying about removing any container still alive and orphaned. This could've been done from the apps point of view, but this is easier/faster